### PR TITLE
[Fix] join 시 uid가 이미 존재할 경우 예외처리

### DIFF
--- a/personal-blog-service/src/user/service/user-auth.service.ts
+++ b/personal-blog-service/src/user/service/user-auth.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable, NotAcceptableException, UnauthorizedException } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { UserAuthRequestDto } from '../dto/user-auth-request.dto';
@@ -25,6 +25,15 @@ export class UserAuthService {
   ) {}
 
   async createNewUser(userAuthRequestDto: UserAuthRequestDto): Promise<JwtDto> {
+    const isExist = await this.userAuthRepository.isExist(
+      userAuthRequestDto.uid,
+    );
+    if (isExist) {
+      throw new NotAcceptableException(
+        `User already exists. - [${userAuthRequestDto.uid}]`,
+      );
+    }
+
     const userRole = UserRole.USER;
     const salt = new Date().getTime().toString();
 


### PR DESCRIPTION
회원가입 할 때 uid가 이미 존재할 경우 typeorm의 save는 upsert를 진행한다.
그래서 isExist를 통해 이미 uid가 존재할 경우 exception을 던져주도록 수정.

related to: #4 