### PR TITLE
[Fix] JwtService 테스트 에러 오류 수정

### DIFF
--- a/personal-blog-service/src/config/winstonConfig.ts
+++ b/personal-blog-service/src/config/winstonConfig.ts
@@ -13,8 +13,9 @@ export const winstonConfig: WinstonModuleAsyncOptions = {
         new winston.transports.Console({
           level: process.env.NODE_ENV === 'production' ? 'info' : 'silly',
         }),
-        new winstonDaily(dailyOption('info')),
-        new winstonDaily(dailyOption('error')),
+        process.env.NODE_ENV === 'production'
+          ? new winstonDaily(dailyOption('error'))
+          : new winstonDaily(dailyOption('info')),
       ],
     };
   },

--- a/personal-blog-service/src/user/service/jwt.service.spec.ts
+++ b/personal-blog-service/src/user/service/jwt.service.spec.ts
@@ -23,6 +23,8 @@ describe('JwtService', () => {
           provide: WINSTON_MODULE_PROVIDER,
           useValue: {
             info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
           },
         },
         {
@@ -52,23 +54,26 @@ describe('JwtService', () => {
 
   describe('create Token', () => {
     it('create new token', async () => {
+      // Given
       const expectUid = 'uid@test.com';
       const userRole = UserRole.USER;
 
+      // When
       const accessToken = (await jwtService.create(expectUid, userRole))
         .accessToken;
-
       const actualUid = CryptoUtils.decryptPrimaryKey(
         (jwt.verify(accessToken, config.jwtSecretKey) as jwt.JwtPayload)['uid'],
         config.pkSecretKey,
       );
 
+      // Then
       expect(actualUid).toEqual(expectUid);
     });
   });
 
   describe('Reissue Token', () => {
     it('Test reissue access token', async () => {
+      // Given
       const expectUid = 'uid@test.com';
       const userRole = UserRole.USER;
       const refreshToken = (await jwtService.create(expectUid, userRole))
@@ -79,6 +84,7 @@ describe('JwtService', () => {
         userRole,
       );
 
+      // When
       const accessToken = (
         await jwtService.reissueJwtByUserSessionEntity(userSessionEntity)
       ).accessToken;
@@ -87,10 +93,12 @@ describe('JwtService', () => {
         config.pkSecretKey,
       );
 
+      // Then
       expect(actualUid).toEqual(expectUid);
     });
 
     it('Test verify refresh token throw error', async () => {
+      // Given
       const expectUid = 'uid@test.com';
       const userRole = UserRole.USER;
       const refreshToken = (await jwtService.create(expectUid, userRole))
@@ -105,9 +113,11 @@ describe('JwtService', () => {
         .fn()
         .mockResolvedValue(userSessionEntity);
 
-      await expect(jwtService.verifyRefreshToken(refreshToken)).rejects.toThrow(
-        UnauthorizedException,
-      );
+      // When
+      const actualException = await jwtService.verifyRefreshToken(refreshToken);
+
+      // Then
+      expect(actualException).toBeInstanceOf(UnauthorizedException);
     });
   });
 });

--- a/personal-blog-service/src/user/service/user-auth.service.ts
+++ b/personal-blog-service/src/user/service/user-auth.service.ts
@@ -1,4 +1,9 @@
-import { Inject, Injectable, NotAcceptableException, UnauthorizedException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  NotAcceptableException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { UserAuthRequestDto } from '../dto/user-auth-request.dto';


### PR DESCRIPTION
verifyRefreshToken 메서드는 Guard에서 exception을 반환받아서 처리하도록 되어 있다.
그래서 exception을 throw하지 않기 때문에, toBeInstanceOf를 활용해 
반환된 타입이 의도한 exception인지 확인하도록 수정한다.