### PR TITLE
[Refactor] Entity 필드의 readonly 접근 제한자 제거

### DIFF
--- a/src/blog/entities/post-like.entity.ts
+++ b/src/blog/entities/post-like.entity.ts
@@ -12,30 +12,30 @@ import { UserAuthEntity } from '../../user/entities/user-auth.entity';
 @Entity('POST_LIKE')
 export class PostLikeEntity {
   @PrimaryColumn({ name: 'POST_ID' })
-  readonly postId: number;
+  postId: number;
 
   @PrimaryColumn({ name: 'UID', length: 100 })
-  readonly uid: string;
+  uid: string;
 
   @CreateDateColumn({
     name: 'CREATE_DATETIME',
     type: 'datetime',
   })
-  readonly createDatetime: Date;
+  createDatetime: Date;
 
   @UpdateDateColumn({
     name: 'MODIFY_DATETIME',
     type: 'datetime',
   })
-  readonly modifyDatetime: Date;
+  modifyDatetime: Date;
 
   @ManyToOne(() => PostEntity, (postEntity) => postEntity.postId)
   @JoinColumn({ name: 'POST_ID', referencedColumnName: 'postId' })
-  readonly postEntity: PostEntity;
+  postEntity: PostEntity;
 
   @ManyToOne(() => UserAuthEntity, (userAuthEntity) => userAuthEntity.uid)
   @JoinColumn({ name: 'UID', referencedColumnName: 'uid' })
-  readonly userAuthEntity: UserAuthEntity;
+  userAuthEntity: UserAuthEntity;
 
   constructor(postId: number, uid: string) {
     this.postId = postId;

--- a/src/blog/entities/post.entity.ts
+++ b/src/blog/entities/post.entity.ts
@@ -15,46 +15,46 @@ import { UserAuthEntity } from '../../user/entities/user-auth.entity';
 @Entity('POST')
 export class PostEntity {
   @PrimaryGeneratedColumn('increment', { name: 'POST_ID' })
-  readonly postId: number;
+  postId: number;
 
   @Index()
   @Column({ name: 'POST_UID', length: 100 })
-  readonly postUid: string;
+  postUid: string;
 
   @Column({ name: 'TITLE', length: 500 })
-  readonly title: string;
+  title: string;
 
   @CreateDateColumn({ name: 'WRITE_DATETIME', type: 'datetime' })
-  readonly writeDatetime: Date;
+  writeDatetime: Date;
 
   @Column({ name: 'CONTENTS', type: 'text' })
-  readonly contents: string;
+  contents: string;
 
   @Column({ name: 'HITS', default: 0 })
-  readonly hits: number;
+  hits: number;
 
   @CreateDateColumn({
     name: 'CREATE_DATETIME',
     type: 'datetime',
   })
-  readonly createDatetime: Date;
+  createDatetime: Date;
 
   @UpdateDateColumn({
     name: 'MODIFY_DATETIME',
     type: 'datetime',
   })
-  readonly modifyDatetime: Date;
+  modifyDatetime: Date;
 
   @OneToMany(
     () => PostLikeEntity,
     (postLikeEntity) => postLikeEntity.postEntity,
     { onDelete: 'CASCADE' },
   )
-  readonly postLikeEntitys: PostLikeEntity[];
+  postLikeEntitys: PostLikeEntity[];
 
   @ManyToOne(() => UserAuthEntity, (userAuthEntity) => userAuthEntity.uid)
   @JoinColumn({ name: 'POST_UID', referencedColumnName: 'uid' })
-  readonly userAuthEntity: UserAuthEntity;
+  userAuthEntity: UserAuthEntity;
 
   constructor(
     postId: number,

--- a/src/user/entities/user-auth.entity.ts
+++ b/src/user/entities/user-auth.entity.ts
@@ -15,49 +15,49 @@ import { PostEntity } from '../../blog/entities/post.entity';
 @Entity('USER_AUTH')
 export class UserAuthEntity {
   @PrimaryColumn({ name: 'UID', length: 100 })
-  readonly uid: string;
+  uid: string;
 
   @Column({ name: 'PASSWORD', length: 1000 })
-  readonly password: string;
+  password: string;
 
   @Column({ name: 'SALT', length: 50 })
-  readonly salt: string;
+  salt: string;
 
   @Column({ name: 'SOCIAL_YN', type: 'char', length: 1 })
-  readonly socialYN: string;
+  socialYN: string;
 
   @Column({ name: 'REFRESH_TOKEN', length: 500 })
-  readonly refreshToken: string;
+  refreshToken: string;
 
   @Column({ name: 'USER_ROLE', type: 'enum', enum: UserRole })
-  readonly userRole: UserRole;
+  userRole: UserRole;
 
   @CreateDateColumn({
     name: 'CREATE_DATETIME',
     type: 'datetime',
   })
-  readonly createDatetime: Date;
+  createDatetime: Date;
 
   @UpdateDateColumn({
     name: 'MODIFY_DATETIME',
     type: 'datetime',
   })
-  readonly modifyDatetime: Date;
+  modifyDatetime: Date;
 
   @OneToOne(() => UserInfoEntity, (userInfoEntity) => userInfoEntity.uid, {
     onDelete: 'CASCADE',
   })
-  readonly userInfo: UserInfoEntity;
+  userInfo: UserInfoEntity;
 
   @OneToMany(() => PostEntity, (postEntity) => postEntity.postUid, {
     onDelete: 'CASCADE',
   })
-  readonly postEntitys: PostEntity[];
+  postEntitys: PostEntity[];
 
   @OneToMany(() => PostLikeEntity, (postLikeEntity) => postLikeEntity.uid, {
     onDelete: 'CASCADE',
   })
-  readonly postLikeEntitys: PostLikeEntity[];
+  postLikeEntitys: PostLikeEntity[];
 
   constructor(
     uid: string,

--- a/src/user/entities/user-info.entity.ts
+++ b/src/user/entities/user-info.entity.ts
@@ -14,29 +14,29 @@ import { UserAuthEntity } from './user-auth.entity';
 @Unique(['nickname'])
 export class UserInfoEntity {
   @PrimaryColumn({ name: 'UID', length: 100 })
-  readonly uid: string;
+  uid: string;
 
   @Column({ name: 'NICKNAME', length: 100 })
-  readonly nickname: string;
+  nickname: string;
 
   @Column({ name: 'INTRODUCE', length: 500 })
-  readonly introduce: string;
+  introduce: string;
 
   @CreateDateColumn({
     name: 'CREATE_DATETIME',
     type: 'datetime',
   })
-  readonly createDatetime: Date;
+  createDatetime: Date;
 
   @UpdateDateColumn({
     name: 'MODIFY_DATETIME',
     type: 'datetime',
   })
-  readonly modifyDatetime: Date;
+  modifyDatetime: Date;
 
   @OneToOne(() => UserAuthEntity, (userAuthEntity) => userAuthEntity.uid)
   @JoinColumn({ name: 'UID', referencedColumnName: 'uid' })
-  readonly userAuthEntity: UserAuthEntity;
+  userAuthEntity: UserAuthEntity;
 
   constructor(uid: string, nickname: string, introduce: string) {
     this.uid = uid;


### PR DESCRIPTION
## 요약

- TypeORM Entity 필드에서 readonly 접근 제한자 제거
- TypeORM 컨벤션 준수 및 코드 일관성 개선

Closes #37

## 변경 사항

### 수정된 파일
- `src/blog/entities/post.entity.ts`
- `src/blog/entities/post-like.entity.ts`
- `src/user/entities/user-auth.entity.ts`
- `src/user/entities/user-info.entity.ts`

### 변경 내용
- 모든 Entity 필드에서 `readonly` 제거

## 변경 근거

1. **TypeORM 컨벤션**: Entity는 일반적으로 mutable하게 관리됨
2. **유지보수성**: Repository의 update 작업 시 객체 속성 직접 수정 가능
3. **테스트 용이성**: 테스트 중 Entity 인스턴스 값 변경 용이
4. **런타임 일관성**: TypeORM은 런타임에 readonly를 무시하므로, 코드 의도와 실제 동작 간 불일치 해소

## 테스트

`Test Suites: 6 passed, 6 total Tests: 33 passed, 33 total`