### PR TITLE
[Refactor] DecryptPrimaryKeyPipe 복호화 실패 시 서버 로깅 추가

### DIFF
--- a/src/pipe/decrypt-primary-key.pipe.spec.ts
+++ b/src/pipe/decrypt-primary-key.pipe.spec.ts
@@ -5,9 +5,15 @@ import { CryptoUtils } from '../utils/crypto.utils';
 describe('DecryptPrimaryKeyPipe', () => {
   const pkSecretKey = 'test-secret-key!';
   let pipe: DecryptPrimaryKeyPipe;
+  let mockLogger: { warn: jest.Mock };
 
   beforeAll(() => {
-    pipe = new DecryptPrimaryKeyPipe({ pkSecretKey } as any);
+    mockLogger = { warn: jest.fn() };
+    pipe = new DecryptPrimaryKeyPipe(mockLogger as any, { pkSecretKey } as any);
+  });
+
+  beforeEach(() => {
+    mockLogger.warn.mockClear();
   });
 
   it('암호화된 값을 복호화하여 반환한다', () => {
@@ -48,5 +54,19 @@ describe('DecryptPrimaryKeyPipe', () => {
 
     // When & Then
     expect(() => pipe.transform(emptyValue)).toThrow(BadRequestException);
+  });
+
+  it('복호화 실패 시 서버 로그에 경고를 기록한다', () => {
+    // Given
+    const invalidValue = 'not-a-valid-encrypted-value';
+
+    // When
+    expect(() => pipe.transform(invalidValue)).toThrow(BadRequestException);
+
+    // Then
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to decrypt primary key parameter.'),
+    );
   });
 });

--- a/src/pipe/decrypt-primary-key.pipe.ts
+++ b/src/pipe/decrypt-primary-key.pipe.ts
@@ -5,12 +5,16 @@ import {
   PipeTransform,
 } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
 import authConfig from '../config/authConfig';
 import { CryptoUtils } from '../utils/crypto.utils';
 
 @Injectable()
 export class DecryptPrimaryKeyPipe implements PipeTransform<string, string> {
   constructor(
+    @Inject(WINSTON_MODULE_PROVIDER)
+    private readonly logger: Logger,
     @Inject(authConfig.KEY)
     private readonly config: ConfigType<typeof authConfig>,
   ) {}
@@ -25,7 +29,14 @@ export class DecryptPrimaryKeyPipe implements PipeTransform<string, string> {
         throw new Error('Decryption produced empty result');
       }
       return decrypted;
-    } catch {
+    } catch (error) {
+      this.logger.warn(
+        `Failed to decrypt primary key parameter. - [${JSON.stringify({
+          value,
+          error: error instanceof Error ? error.message : String(error),
+        })}]`,
+      );
+
       throw new BadRequestException('Invalid encrypted parameter');
     }
   }


### PR DESCRIPTION
## Summary
- `DecryptPrimaryKeyPipe`에 Winston 로거를 주입하여 복호화 실패 시 warn 레벨로 입력값과 에러 메시지를 서버 로그에 기록
- 클라이언트 응답 메시지는 기존과 동일하게 유지 (`Invalid encrypted parameter`)

Closes #48