### PR TITLE
[Refactor] TypeScript strictBindCallApply 활성화

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "skipLibCheck": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
-    "strictBindCallApply": false,
+    "strictBindCallApply": true,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false
   }


### PR DESCRIPTION
## Summary
- `tsconfig.json`에서 `strictBindCallApply: true` 설정
- `bind`, `call`, `apply` 메서드 호출 시 인수 타입을 컴파일 타임에 검증
- 점진적 strict 모드 전환의 일환 (#46 후속)

## Changes
- `tsconfig.json`: `strictBindCallApply: false` → `true`

## Test
- [x] TypeScript 컴파일 에러 없음 (`npx tsc --noEmit`)
- [x] 전체 단위 테스트 통과 (8 suites, 46 tests)
- [x] 빌드 성공 (`npm run build`)

Closes #51