### PR TITLE
[Fix] PostRepository에서 EntityNotFoundError를 NotFoundException으로 변환

### DIFF
--- a/src/blog/repository/post.repository.ts
+++ b/src/blog/repository/post.repository.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PostEntity } from '../entities/post.entity';
-import { Repository } from 'typeorm';
+import { EntityNotFoundError, Repository } from 'typeorm';
 import { PaginationUtils } from '../../utils/pagination.utils';
 import { CacheIdUtils } from '../../utils/cache-id.utils';
 import { TimeUtils } from '../../utils/time.utils';
@@ -60,7 +60,15 @@ export class PostRepository {
   }
 
   async findPostEntityByPostId(postId: number): Promise<PostEntity> {
-    return await this.postRepository.findOneByOrFail({ postId });
+    try {
+      return await this.postRepository.findOneByOrFail({ postId });
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) {
+        throw new NotFoundException(`Post does not exist! - [${postId}]`);
+      }
+
+      throw error;
+    }
   }
 
   async updatePost(


### PR DESCRIPTION
## 요약

`PostRepository.findPostEntityByPostId`에서 존재하지 않는 게시글 조회 시 `EntityNotFoundError`가 변환 없이 전파되어 500 에러로 응답되던 버그를 수정한다.

## 문제

- 존재하지 않는 `postId`로 `GET /blogs/posts/{postId}` 호출 시 `EntityNotFoundError` 발생
- `UnhandledExceptionFilter`가 잡아 500 `INTERNAL_SERVER_ERROR`로 응답

## 원인

- `findPostEntityByPostId`에서 `findOneByOrFail` 사용 시 발생하는 `EntityNotFoundError`에 대한 catch 처리가 누락됨

## 해결

- `try-catch`를 추가하여 `EntityNotFoundError` → `NotFoundException`으로 변환
- `UserAuthRepository`, `UserInfoRepository`에 이미 적용된 동일 패턴 적용

## 테스트

- [x] 기존 단위 테스트 전체 통과 (`post.service.spec.ts` 11건)
- [x] lint 통과

## 관련 이슈

Closes #57