### PR TITLE
[Refactor] FailureResponse 생성자의 ErrorCode/HttpStatus 타입 불일치 해소

### DIFF
--- a/src/filter/abstract-exception.filter.ts
+++ b/src/filter/abstract-exception.filter.ts
@@ -2,6 +2,7 @@ import { HttpStatus, Inject } from '@nestjs/common';
 import { Response } from 'express';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
+import { ErrorCode } from '../constant/error-code.enum';
 import { FailureResponse } from '../response/failure-response.dto';
 
 export abstract class AbstractExceptionFilter {
@@ -26,7 +27,7 @@ export abstract class AbstractExceptionFilter {
 
   protected sendFailureResponse(
     res: Response,
-    code: number,
+    code: HttpStatus | ErrorCode,
     message: string,
   ): void {
     res.status(HttpStatus.OK).json(new FailureResponse(code, message));

--- a/src/response/base-response.dto.ts
+++ b/src/response/base-response.dto.ts
@@ -1,10 +1,11 @@
 import { HttpStatus } from '@nestjs/common';
+import { ErrorCode } from '../constant/error-code.enum';
 
 export abstract class BaseResponse {
   readonly code: number;
   readonly message: string;
 
-  constructor(code: HttpStatus, message: string) {
+  constructor(code: HttpStatus | ErrorCode, message: string) {
     this.code = code;
     this.message = message;
   }

--- a/src/response/failure-response.dto.ts
+++ b/src/response/failure-response.dto.ts
@@ -4,13 +4,13 @@ import { UnexpectedCodeException } from '../exception/unexpected-code.exception'
 import { ErrorCode } from '../constant/error-code.enum';
 
 export class FailureResponse extends BaseResponse {
-  constructor(code: HttpStatus, message: string) {
+  constructor(code: HttpStatus | ErrorCode, message: string) {
     super(code, message);
 
     this.checkCodeOk(this.code);
   }
 
-  private checkCodeOk(code: HttpStatus) {
+  private checkCodeOk(code: HttpStatus | ErrorCode) {
     if (code === HttpStatus.OK) {
       throw new UnexpectedCodeException(
         ErrorCode.NOT_ACCEPTABLE,


### PR DESCRIPTION
## 요약

`FailureResponse` 생성자의 `code` 파라미터 타입이 `HttpStatus`로만 선언되어 있으나 실제로는 `ErrorCode` 값도 전달되는 타입 불일치를 `HttpStatus | ErrorCode` 유니언 타입으로 해소한다.

## 변경 사항

- `BaseResponse` 생성자의 `code` 파라미터 타입: `HttpStatus` → `HttpStatus | ErrorCode`
- `FailureResponse` 생성자 및 `checkCodeOk` 메서드: 동일 타입 수정
- `AbstractExceptionFilter.sendFailureResponse`의 `code` 파라미터: `number` → `HttpStatus | ErrorCode`

## 변경 이유

`BaseExceptionFilter`에서 `exception.errorCode` (`ErrorCode` 타입)를 `sendFailureResponse` → `FailureResponse` 생성자로 전달하지만, 생성자 타입이 `HttpStatus`로만 선언되어 있어 TypeScript 숫자 열거형의 암묵적 호환에 의존하고 있었다. 타입 정의를 실제 사용 패턴과 일치시켜 타입 안전성을 확보한다.

## 테스트

- 단위 테스트: 14 스위트, 72 테스트 전체 통과
- TypeScript 타입 체크 (`tsc --noEmit`) 통과

## 관련 이슈

Closes #58