### PR TITLE
[Refactor] BaseException 직접 사용을 도메인별 구체 예외 클래스로 분리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ src/
 ├── filter/         # 타입별 Exception Filters (BaseException, HttpException, Unhandled)
 ├── interceptor/    # EncryptPrimaryKeyInterceptor (응답 PK 암호화)
 ├── pipe/           # DecryptPrimaryKeyPipe (요청 PK 복호화)
-├── exception/      # Custom exceptions (BaseException, InvalidPageException, UnexpectedCodeException)
+├── exception/      # Custom exceptions (abstract BaseException + 도메인별 하위 디렉토리: auth/, user/, blog/, validation/)
 ├── response/       # BaseResponseDto, SuccessResponse, FailureResponse, Swagger options
 └── utils/          # Crypto, pagination (TAKE=20 고정), cache key, time utilities
 ```
@@ -156,7 +156,14 @@ Standard pagination via `PaginationDto` with page/limit params. 페이지당 고
 | `HttpExceptionFilter` | `HttpException` | NestJS 표준 HTTP 예외 처리 |
 | `UnhandledExceptionFilter` | `()` catch-all | 500 변환, 원본 에러 로깅 |
 
-`BaseException` 계층: `BaseException`(concrete, 직접 인스턴스화 가능) → 서브클래스: `InvalidPageException`, `UnexpectedCodeException`. 대부분의 도메인 예외는 `new BaseException(ErrorCode.XXX, message)`로 직접 생성.
+`BaseException` 계층: `BaseException`(abstract, protected constructor) → 도메인별 구체 예외 클래스:
+- `auth/`: `AuthUnauthorizedException`, `AuthInvalidPasswordException`, `AuthInvalidOauthTokenException`, `AuthRefreshTokenRequiredException`, `AuthInvalidRefreshTokenException`
+- `user/`: `UserNotFoundException`, `UserAlreadyExistsException`, `UserInfoNotFoundException`, `UserInfoAlreadyExistsException`
+- `blog/`: `PostNotFoundException`, `PostLikeAlreadyExistsException`, `PostLikeNotFoundException`
+- `validation/`: `InvalidPageException`, `InvalidEncryptedParameterException`
+- 범용: `UnexpectedCodeException` (어떤 ErrorCode든 받을 수 있는 fallback)
+
+새 예외 추가 시: ErrorCode enum 도메인 그룹과 일치하는 하위 디렉토리에 클래스 생성, barrel index.ts에 export 추가.
 
 ### Logging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Each feature module follows: `Controller → Service → Repository → Entity`
 - Repositories: TypeORM queries
 - DAOs: Entity → DTO transformation
 - DTOs: Request/response validation with class-validator
-- Pipes: `DecryptPrimaryKeyPipe` (암호화된 path param → 복호화, 유효하지 않은 값은 BaseException(INVALID_ENCRYPTED_PARAMETER))
+- Pipes: `DecryptPrimaryKeyPipe` (암호화된 path param → 복호화, 유효하지 않은 값은 InvalidEncryptedParameterException)
 - Interceptors: `EncryptPrimaryKeyInterceptor` (응답 DTO의 `@EncryptField()` 필드 자동 암호화), `SetRefreshTokenCookieInterceptor` (user 모듈, refreshToken 쿠키 자동 설정)
 
 Feature module 내부 구조:

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -8,8 +8,7 @@ import { Request } from 'express';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { Reflector } from '@nestjs/core';
-import { ErrorCode } from '../constant/error-code.enum';
-import { BaseException } from '../exception/base.exception';
+import { AuthUnauthorizedException } from '../exception/auth';
 import { JwtService } from '../user/service/jwt.service';
 
 @Injectable()
@@ -37,7 +36,7 @@ export class AuthGuard implements CanActivate {
         )}]`,
       );
 
-      throw new BaseException(ErrorCode.AUTH_UNAUTHORIZED, 'Unauthorized');
+      throw new AuthUnauthorizedException();
     }
 
     const accessToken = request.headers.authorization.split('Bearer ')[1];
@@ -45,14 +44,14 @@ export class AuthGuard implements CanActivate {
     const verifyResult = await this.jwtService.verifyAccessToken(accessToken);
 
     if (verifyResult instanceof Error) {
-      throw new BaseException(ErrorCode.AUTH_UNAUTHORIZED, 'Unauthorized');
+      throw new AuthUnauthorizedException();
     }
 
     const userSessionEntity =
       await this.jwtService.verifyRefreshToken(refreshToken);
 
     if (userSessionEntity instanceof Error) {
-      throw new BaseException(ErrorCode.AUTH_UNAUTHORIZED, 'Unauthorized');
+      throw new AuthUnauthorizedException();
     }
 
     const roles = this.reflector.getAllAndMerge<string[]>('roles', [

--- a/src/blog/repository/post.repository.ts
+++ b/src/blog/repository/post.repository.ts
@@ -9,8 +9,7 @@ import { PostPageDto } from '../dto/post-page.dto';
 import { CreatePostDto } from '../dto/create-post.dto';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { PatchPostDto } from '../dto/patch-post.dto';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import { PostNotFoundException } from '../../exception/blog';
 
 @Injectable()
 export class PostRepository {
@@ -66,10 +65,7 @@ export class PostRepository {
       return await this.postRepository.findOneByOrFail({ postId });
     } catch (error) {
       if (error instanceof EntityNotFoundError) {
-        throw new BaseException(
-          ErrorCode.POST_NOT_FOUND,
-          `Post does not exist! - [${postId}]`,
-        );
+        throw new PostNotFoundException(postId);
       }
 
       throw error;

--- a/src/blog/service/post-like.service.ts
+++ b/src/blog/service/post-like.service.ts
@@ -6,8 +6,10 @@ import { PostLikeRepository } from '../repository/post-like.repository';
 import { PostLikeEntity } from '../entities/post-like.entity';
 import { PostLikeDao } from '../dao/post-like.dao';
 import { PostLikeDto } from '../dto/post-like.dto';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import {
+  PostLikeAlreadyExistsException,
+  PostLikeNotFoundException,
+} from '../../exception/blog';
 
 @Injectable()
 export class PostLikeService {
@@ -51,10 +53,7 @@ export class PostLikeService {
     const postLikeEntity = this.toPostLikeEntity(postLikeDto);
     const isExist = await this.postLikeRepository.isExist(postLikeEntity);
     if (isExist) {
-      throw new BaseException(
-        ErrorCode.POST_LIKE_ALREADY_EXISTS,
-        'Post like already exists!',
-      );
+      throw new PostLikeAlreadyExistsException();
     }
 
     await this.postLikeRepository.savePostLikeEntity(postLikeEntity);
@@ -66,10 +65,7 @@ export class PostLikeService {
     const postLikeEntity = this.toPostLikeEntity(postLikeDto);
     const isExist = await this.postLikeRepository.isExist(postLikeEntity);
     if (!isExist) {
-      throw new BaseException(
-        ErrorCode.POST_LIKE_NOT_FOUND,
-        'Post like not found!',
-      );
+      throw new PostLikeNotFoundException();
     }
 
     await this.postLikeRepository.removePostLikeEntity(postLikeEntity);

--- a/src/decorator/authenticated-user-validation.decorator.ts
+++ b/src/decorator/authenticated-user-validation.decorator.ts
@@ -1,7 +1,6 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Request } from 'express';
-import { ErrorCode } from '../constant/error-code.enum';
-import { BaseException } from '../exception/base.exception';
+import { AuthUnauthorizedException } from '../exception/auth';
 
 export const AuthenticatedUserValidation = createParamDecorator(
   (data: string, ctx: ExecutionContext) => {
@@ -9,10 +8,7 @@ export const AuthenticatedUserValidation = createParamDecorator(
     const authenticatedUser = request.headers.authenticatedUser;
 
     if (!authenticatedUser) {
-      throw new BaseException(
-        ErrorCode.AUTH_UNAUTHORIZED,
-        'AuthenticatedUid does not exists.',
-      );
+      throw new AuthUnauthorizedException('AuthenticatedUid does not exists.');
     }
 
     return authenticatedUser;

--- a/src/exception/auth/auth-invalid-oauth-token.exception.ts
+++ b/src/exception/auth/auth-invalid-oauth-token.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class AuthInvalidOauthTokenException extends BaseException {
+  constructor(detail?: string) {
+    super(ErrorCode.AUTH_INVALID_OAUTH_TOKEN, detail ?? 'Invalid OAuth token.');
+  }
+}

--- a/src/exception/auth/auth-invalid-password.exception.ts
+++ b/src/exception/auth/auth-invalid-password.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class AuthInvalidPasswordException extends BaseException {
+  constructor() {
+    super(ErrorCode.AUTH_INVALID_PASSWORD, 'Password does not match.');
+  }
+}

--- a/src/exception/auth/auth-invalid-refresh-token.exception.ts
+++ b/src/exception/auth/auth-invalid-refresh-token.exception.ts
@@ -1,0 +1,11 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class AuthInvalidRefreshTokenException extends BaseException {
+  constructor(context?: string) {
+    super(
+      ErrorCode.AUTH_INVALID_REFRESH_TOKEN,
+      context ?? 'Invalid refresh token.',
+    );
+  }
+}

--- a/src/exception/auth/auth-refresh-token-required.exception.ts
+++ b/src/exception/auth/auth-refresh-token-required.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class AuthRefreshTokenRequiredException extends BaseException {
+  constructor() {
+    super(ErrorCode.AUTH_REFRESH_TOKEN_REQUIRED, 'Refresh token is required.');
+  }
+}

--- a/src/exception/auth/auth-unauthorized.exception.ts
+++ b/src/exception/auth/auth-unauthorized.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class AuthUnauthorizedException extends BaseException {
+  constructor(context?: string) {
+    super(ErrorCode.AUTH_UNAUTHORIZED, context ?? 'Unauthorized');
+  }
+}

--- a/src/exception/auth/index.ts
+++ b/src/exception/auth/index.ts
@@ -1,0 +1,5 @@
+export { AuthUnauthorizedException } from './auth-unauthorized.exception';
+export { AuthInvalidPasswordException } from './auth-invalid-password.exception';
+export { AuthInvalidOauthTokenException } from './auth-invalid-oauth-token.exception';
+export { AuthRefreshTokenRequiredException } from './auth-refresh-token-required.exception';
+export { AuthInvalidRefreshTokenException } from './auth-invalid-refresh-token.exception';

--- a/src/exception/base.exception.ts
+++ b/src/exception/base.exception.ts
@@ -1,11 +1,11 @@
 import { ErrorCode } from '../constant/error-code.enum';
 
-export class BaseException extends Error {
+export abstract class BaseException extends Error {
   readonly errorCode: ErrorCode;
   readonly message: string;
   readonly value?: string;
 
-  constructor(errorCode: ErrorCode, message: string, value?: string) {
+  protected constructor(errorCode: ErrorCode, message: string, value?: string) {
     super();
 
     this.errorCode = errorCode;

--- a/src/exception/blog/index.ts
+++ b/src/exception/blog/index.ts
@@ -1,0 +1,3 @@
+export { PostNotFoundException } from './post-not-found.exception';
+export { PostLikeAlreadyExistsException } from './post-like-already-exists.exception';
+export { PostLikeNotFoundException } from './post-like-not-found.exception';

--- a/src/exception/blog/post-like-already-exists.exception.ts
+++ b/src/exception/blog/post-like-already-exists.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class PostLikeAlreadyExistsException extends BaseException {
+  constructor() {
+    super(ErrorCode.POST_LIKE_ALREADY_EXISTS, 'Post like already exists.');
+  }
+}

--- a/src/exception/blog/post-like-not-found.exception.ts
+++ b/src/exception/blog/post-like-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class PostLikeNotFoundException extends BaseException {
+  constructor() {
+    super(ErrorCode.POST_LIKE_NOT_FOUND, 'Post like not found.');
+  }
+}

--- a/src/exception/blog/post-not-found.exception.ts
+++ b/src/exception/blog/post-not-found.exception.ts
@@ -3,6 +3,6 @@ import { BaseException } from '../base.exception';
 
 export class PostNotFoundException extends BaseException {
   constructor(postId: number) {
-    super(ErrorCode.POST_NOT_FOUND, `Post does not exist. - [${postId}]`);
+    super(ErrorCode.POST_NOT_FOUND, `Post does not exist! - [${postId}]`);
   }
 }

--- a/src/exception/blog/post-not-found.exception.ts
+++ b/src/exception/blog/post-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class PostNotFoundException extends BaseException {
+  constructor(postId: number) {
+    super(ErrorCode.POST_NOT_FOUND, `Post does not exist. - [${postId}]`);
+  }
+}

--- a/src/exception/invalid-page.exception.ts
+++ b/src/exception/invalid-page.exception.ts
@@ -1,12 +1,1 @@
-import { ErrorCode } from '../constant/error-code.enum';
-import { BaseException } from './base.exception';
-
-export class InvalidPageException extends BaseException {
-  constructor(page: number) {
-    super(
-      ErrorCode.INVALID_PAGE,
-      `Invalid page number: ${page}. Page must be >= 1`,
-      String(page),
-    );
-  }
-}
+export { InvalidPageException } from './validation/invalid-page.exception';

--- a/src/exception/user/index.ts
+++ b/src/exception/user/index.ts
@@ -1,0 +1,4 @@
+export { UserNotFoundException } from './user-not-found.exception';
+export { UserAlreadyExistsException } from './user-already-exists.exception';
+export { UserInfoNotFoundException } from './user-info-not-found.exception';
+export { UserInfoAlreadyExistsException } from './user-info-already-exists.exception';

--- a/src/exception/user/user-already-exists.exception.ts
+++ b/src/exception/user/user-already-exists.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class UserAlreadyExistsException extends BaseException {
+  constructor(uid: string) {
+    super(ErrorCode.USER_ALREADY_EXISTS, `User already exists. - [${uid}]`);
+  }
+}

--- a/src/exception/user/user-info-already-exists.exception.ts
+++ b/src/exception/user/user-info-already-exists.exception.ts
@@ -1,0 +1,11 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class UserInfoAlreadyExistsException extends BaseException {
+  constructor(uid: string) {
+    super(
+      ErrorCode.USER_INFO_ALREADY_EXISTS,
+      `UserInfo already exists. - [${uid}]`,
+    );
+  }
+}

--- a/src/exception/user/user-info-not-found.exception.ts
+++ b/src/exception/user/user-info-not-found.exception.ts
@@ -3,6 +3,6 @@ import { BaseException } from '../base.exception';
 
 export class UserInfoNotFoundException extends BaseException {
   constructor(uid: string) {
-    super(ErrorCode.USER_INFO_NOT_FOUND, `UserInfo does not exist. - [${uid}]`);
+    super(ErrorCode.USER_INFO_NOT_FOUND, `User does not exist! - [${uid}]`);
   }
 }

--- a/src/exception/user/user-info-not-found.exception.ts
+++ b/src/exception/user/user-info-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class UserInfoNotFoundException extends BaseException {
+  constructor(uid: string) {
+    super(ErrorCode.USER_INFO_NOT_FOUND, `UserInfo does not exist. - [${uid}]`);
+  }
+}

--- a/src/exception/user/user-not-found.exception.ts
+++ b/src/exception/user/user-not-found.exception.ts
@@ -1,0 +1,8 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class UserNotFoundException extends BaseException {
+  constructor(uid: string) {
+    super(ErrorCode.USER_NOT_FOUND, `User does not exist. - [${uid}]`);
+  }
+}

--- a/src/exception/user/user-not-found.exception.ts
+++ b/src/exception/user/user-not-found.exception.ts
@@ -3,6 +3,6 @@ import { BaseException } from '../base.exception';
 
 export class UserNotFoundException extends BaseException {
   constructor(uid: string) {
-    super(ErrorCode.USER_NOT_FOUND, `User does not exist. - [${uid}]`);
+    super(ErrorCode.USER_NOT_FOUND, `User does not exist! - [${uid}]`);
   }
 }

--- a/src/exception/validation/index.ts
+++ b/src/exception/validation/index.ts
@@ -1,0 +1,2 @@
+export { InvalidPageException } from './invalid-page.exception';
+export { InvalidEncryptedParameterException } from './invalid-encrypted-parameter.exception';

--- a/src/exception/validation/invalid-encrypted-parameter.exception.ts
+++ b/src/exception/validation/invalid-encrypted-parameter.exception.ts
@@ -1,0 +1,11 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class InvalidEncryptedParameterException extends BaseException {
+  constructor() {
+    super(
+      ErrorCode.INVALID_ENCRYPTED_PARAMETER,
+      'Invalid encrypted parameter.',
+    );
+  }
+}

--- a/src/exception/validation/invalid-page.exception.ts
+++ b/src/exception/validation/invalid-page.exception.ts
@@ -1,0 +1,12 @@
+import { ErrorCode } from '../../constant/error-code.enum';
+import { BaseException } from '../base.exception';
+
+export class InvalidPageException extends BaseException {
+  constructor(page: number) {
+    super(
+      ErrorCode.INVALID_PAGE,
+      `Invalid page number: ${page}. Page must be >= 1`,
+      String(page),
+    );
+  }
+}

--- a/src/pipe/decrypt-primary-key.pipe.spec.ts
+++ b/src/pipe/decrypt-primary-key.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { DecryptPrimaryKeyPipe } from './decrypt-primary-key.pipe';
 import { CryptoUtils } from '../utils/crypto.utils';
-import { BaseException } from '../exception/base.exception';
+import { InvalidEncryptedParameterException } from '../exception/validation';
 
 describe('DecryptPrimaryKeyPipe', () => {
   const pkSecretKey = 'test-secret-key!';
@@ -40,20 +40,24 @@ describe('DecryptPrimaryKeyPipe', () => {
     expect(result).toBe(uuid);
   });
 
-  it('유효하지 않은 암호문이 입력되면 BaseException을 던진다', () => {
+  it('유효하지 않은 암호문이 입력되면 InvalidEncryptedParameterException을 던진다', () => {
     // Given
     const invalidValue = 'not-a-valid-encrypted-value';
 
     // When & Then
-    expect(() => pipe.transform(invalidValue)).toThrow(BaseException);
+    expect(() => pipe.transform(invalidValue)).toThrow(
+      InvalidEncryptedParameterException,
+    );
   });
 
-  it('빈 문자열이 입력되면 BaseException을 던진다', () => {
+  it('빈 문자열이 입력되면 InvalidEncryptedParameterException을 던진다', () => {
     // Given
     const emptyValue = '';
 
     // When & Then
-    expect(() => pipe.transform(emptyValue)).toThrow(BaseException);
+    expect(() => pipe.transform(emptyValue)).toThrow(
+      InvalidEncryptedParameterException,
+    );
   });
 
   it('복호화 실패 시 서버 로그에 경고를 기록한다', () => {
@@ -61,7 +65,9 @@ describe('DecryptPrimaryKeyPipe', () => {
     const invalidValue = 'not-a-valid-encrypted-value';
 
     // When
-    expect(() => pipe.transform(invalidValue)).toThrow(BaseException);
+    expect(() => pipe.transform(invalidValue)).toThrow(
+      InvalidEncryptedParameterException,
+    );
 
     // Then
     expect(mockLogger.warn).toHaveBeenCalledTimes(1);

--- a/src/pipe/decrypt-primary-key.pipe.ts
+++ b/src/pipe/decrypt-primary-key.pipe.ts
@@ -4,8 +4,7 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import authConfig from '../config/authConfig';
 import { CryptoUtils } from '../utils/crypto.utils';
-import { ErrorCode } from '../constant/error-code.enum';
-import { BaseException } from '../exception/base.exception';
+import { InvalidEncryptedParameterException } from '../exception/validation';
 
 @Injectable()
 export class DecryptPrimaryKeyPipe implements PipeTransform<string, string> {
@@ -34,10 +33,7 @@ export class DecryptPrimaryKeyPipe implements PipeTransform<string, string> {
         })}]`,
       );
 
-      throw new BaseException(
-        ErrorCode.INVALID_ENCRYPTED_PARAMETER,
-        'Invalid encrypted parameter',
-      );
+      throw new InvalidEncryptedParameterException();
     }
   }
 }

--- a/src/user/repository/user-auth.repository.ts
+++ b/src/user/repository/user-auth.repository.ts
@@ -7,8 +7,7 @@ import { CacheIdUtils } from '../../utils/cache-id.utils';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { TimeUtils } from '../../utils/time.utils';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import { UserNotFoundException } from '../../exception/user';
 
 @Injectable()
 export class UserAuthRepository {
@@ -33,10 +32,7 @@ export class UserAuthRepository {
       ]);
 
       if (error instanceof EntityNotFoundError) {
-        throw new BaseException(
-          ErrorCode.USER_NOT_FOUND,
-          `User does not exist! - [${uid}]`,
-        );
+        throw new UserNotFoundException(uid);
       }
 
       throw error;
@@ -69,10 +65,7 @@ export class UserAuthRepository {
       ]);
 
       if (error instanceof EntityNotFoundError) {
-        throw new BaseException(
-          ErrorCode.USER_NOT_FOUND,
-          `User does not exist! - [${uid}]`,
-        );
+        throw new UserNotFoundException(uid);
       }
 
       throw error;

--- a/src/user/repository/user-info.repository.ts
+++ b/src/user/repository/user-info.repository.ts
@@ -4,8 +4,7 @@ import { UserInfoEntity } from '../entities/user-info.entity';
 import { DataSource, EntityNotFoundError, Repository } from 'typeorm';
 import { CacheIdUtils } from '../../utils/cache-id.utils';
 import { TimeUtils } from '../../utils/time.utils';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import { UserInfoNotFoundException } from '../../exception/user';
 
 @Injectable()
 export class UserInfoRepository {
@@ -36,10 +35,7 @@ export class UserInfoRepository {
       await this.removeUserInfoCache(uid);
 
       if (error instanceof EntityNotFoundError) {
-        throw new BaseException(
-          ErrorCode.USER_INFO_NOT_FOUND,
-          `User does not exist! - [${uid}]`,
-        );
+        throw new UserInfoNotFoundException(uid);
       }
 
       throw error;

--- a/src/user/service/jwt.service.spec.ts
+++ b/src/user/service/jwt.service.spec.ts
@@ -4,7 +4,7 @@ import * as jwt from 'jsonwebtoken';
 import { ConfigType } from '@nestjs/config';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import authConfig from '../../config/authConfig';
-import { BaseException } from '../../exception/base.exception';
+import { AuthInvalidRefreshTokenException } from '../../exception/auth';
 import { UserRole } from '../../constant/user-role.enum';
 import { CryptoUtils } from '../../utils/crypto.utils';
 import { UserSessionEntity } from '../entities/user-session.entity';
@@ -120,7 +120,7 @@ describe('JwtService', () => {
       const actualException = await jwtService.verifyRefreshToken(refreshToken);
 
       // Then
-      expect(actualException).toBeInstanceOf(BaseException);
+      expect(actualException).toBeInstanceOf(AuthInvalidRefreshTokenException);
     });
   });
 });

--- a/src/user/service/jwt.service.ts
+++ b/src/user/service/jwt.service.ts
@@ -9,8 +9,7 @@ import { CryptoUtils } from '../../utils/crypto.utils';
 import { JwtDto } from '../dto/jwt.dto';
 import { UserSessionEntity } from '../entities/user-session.entity';
 import { UserAuthRepository } from '../repository/user-auth.repository';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import { AuthInvalidRefreshTokenException } from '../../exception/auth';
 
 @Injectable()
 export class JwtService {
@@ -74,8 +73,7 @@ export class JwtService {
       if (refreshToken !== userSessionEntity.refreshToken) {
         this.logger.error(`Refresh Token does not match! - [${refreshToken}]`);
 
-        return new BaseException(
-          ErrorCode.AUTH_INVALID_REFRESH_TOKEN,
+        return new AuthInvalidRefreshTokenException(
           'Refresh Token does not match!',
         );
       }

--- a/src/user/service/user-auth.service.spec.ts
+++ b/src/user/service/user-auth.service.spec.ts
@@ -9,7 +9,10 @@ import { JwtDto } from '../dto/jwt.dto';
 import { UserAuthRequestDto } from '../dto/user-auth-request.dto';
 import { UserAuthEntity } from '../entities/user-auth.entity';
 import { OauthRequestDto } from '../dto/oauth-request.dto';
-import { BaseException } from '../../exception/base.exception';
+import {
+  AuthInvalidPasswordException,
+  AuthRefreshTokenRequiredException,
+} from '../../exception/auth';
 
 describe('UserAuthService', () => {
   let userAuthService: UserAuthService;
@@ -128,19 +131,21 @@ describe('UserAuthService', () => {
       // Then
       await expect(
         userAuthService.login(new UserAuthRequestDto(uid, password)),
-      ).rejects.toThrow(BaseException);
+      ).rejects.toThrow(AuthInvalidPasswordException);
     });
   });
 
   describe('refresh', () => {
-    it('refreshToken이 없으면 BaseException을 던진다', async () => {
+    it('refreshToken이 없으면 AuthRefreshTokenRequiredException을 던진다', async () => {
       await expect(userAuthService.refresh(undefined)).rejects.toThrow(
-        BaseException,
+        AuthRefreshTokenRequiredException,
       );
     });
 
-    it('refreshToken이 빈 문자열이면 BaseException을 던진다', async () => {
-      await expect(userAuthService.refresh('')).rejects.toThrow(BaseException);
+    it('refreshToken이 빈 문자열이면 AuthRefreshTokenRequiredException을 던진다', async () => {
+      await expect(userAuthService.refresh('')).rejects.toThrow(
+        AuthRefreshTokenRequiredException,
+      );
     });
   });
 

--- a/src/user/service/user-auth.service.ts
+++ b/src/user/service/user-auth.service.ts
@@ -13,8 +13,13 @@ import { UserAuthDao } from './../dao/user-auth.dao';
 import { JwtService } from './jwt.service';
 import authConfig from '../../config/authConfig';
 import { OauthRequestDto } from '../dto/oauth-request.dto';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import {
+  AuthInvalidOauthTokenException,
+  AuthInvalidPasswordException,
+  AuthInvalidRefreshTokenException,
+  AuthRefreshTokenRequiredException,
+} from '../../exception/auth';
+import { UserAlreadyExistsException } from '../../exception/user';
 
 @Injectable()
 export class UserAuthService {
@@ -32,10 +37,7 @@ export class UserAuthService {
       userAuthRequestDto.uid,
     );
     if (isExist) {
-      throw new BaseException(
-        ErrorCode.USER_ALREADY_EXISTS,
-        `User already exists. - [${userAuthRequestDto.uid}]`,
-      );
+      throw new UserAlreadyExistsException(userAuthRequestDto.uid);
     }
 
     const userRole = UserRole.USER;
@@ -75,10 +77,7 @@ export class UserAuthService {
     );
 
     if (hashedPassword !== userAuthEntity.password) {
-      throw new BaseException(
-        ErrorCode.AUTH_INVALID_PASSWORD,
-        'Password does not match.',
-      );
+      throw new AuthInvalidPasswordException();
     }
 
     return this.jwtService.create(userAuthEntity.uid, userAuthEntity.userRole);
@@ -90,10 +89,7 @@ export class UserAuthService {
     );
     const payload = ticket.getPayload();
     if (!payload?.email) {
-      throw new BaseException(
-        ErrorCode.AUTH_INVALID_OAUTH_TOKEN,
-        'Invalid Google token payload.',
-      );
+      throw new AuthInvalidOauthTokenException('Invalid Google token payload.');
     }
     const uid = payload.email;
     const isExist = await this.userAuthRepository.isExist(uid);
@@ -121,20 +117,14 @@ export class UserAuthService {
 
   async refresh(refreshToken: string | undefined): Promise<JwtDto> {
     if (!refreshToken) {
-      throw new BaseException(
-        ErrorCode.AUTH_REFRESH_TOKEN_REQUIRED,
-        'Refresh token is required.',
-      );
+      throw new AuthRefreshTokenRequiredException();
     }
 
     const userSessionEntity =
       await this.jwtService.verifyRefreshToken(refreshToken);
 
     if (userSessionEntity instanceof Error) {
-      throw new BaseException(
-        ErrorCode.AUTH_INVALID_REFRESH_TOKEN,
-        'Invalid refresh token.',
-      );
+      throw new AuthInvalidRefreshTokenException();
     }
 
     return this.jwtService.reissueJwtByUserSessionEntity(userSessionEntity);
@@ -164,10 +154,7 @@ export class UserAuthService {
         `CredentialToken is not allowed. - [${credentialToken}]`,
       );
 
-      throw new BaseException(
-        ErrorCode.AUTH_INVALID_OAUTH_TOKEN,
-        'This token is not allowed.',
-      );
+      throw new AuthInvalidOauthTokenException('This token is not allowed.');
     }
   }
 }

--- a/src/user/service/user-info.service.ts
+++ b/src/user/service/user-info.service.ts
@@ -4,8 +4,10 @@ import { UserInfoRepository } from '../repository/user-info.repository';
 import { UserInfoDao } from '../dao/user-info.dao';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
-import { ErrorCode } from '../../constant/error-code.enum';
-import { BaseException } from '../../exception/base.exception';
+import {
+  UserInfoAlreadyExistsException,
+  UserInfoNotFoundException,
+} from '../../exception/user';
 
 @Injectable()
 export class UserInfoService {
@@ -18,10 +20,7 @@ export class UserInfoService {
   async createUserInfo(userInfoDto: UserInfoDto): Promise<void> {
     const isExist = await this.userInfoRepository.isExist(userInfoDto.uid);
     if (isExist) {
-      throw new BaseException(
-        ErrorCode.USER_INFO_ALREADY_EXISTS,
-        `UserInfo already exist. - [${userInfoDto.uid}]`,
-      );
+      throw new UserInfoAlreadyExistsException(userInfoDto.uid);
     }
 
     await this.userInfoRepository.saveUserInfoEntity(
@@ -40,10 +39,7 @@ export class UserInfoService {
   async updateUserInfo(userInfoDto: UserInfoDto): Promise<void> {
     const isExist = await this.userInfoRepository.isExist(userInfoDto.uid);
     if (!isExist) {
-      throw new BaseException(
-        ErrorCode.USER_INFO_NOT_FOUND,
-        `UserInfo does not exist. - [${userInfoDto.uid}]`,
-      );
+      throw new UserInfoNotFoundException(userInfoDto.uid);
     }
 
     await this.userInfoRepository.updateUserInfoEntity(
@@ -56,10 +52,7 @@ export class UserInfoService {
   async deleteUserInfoByUid(uid: string): Promise<void> {
     const isExist = await this.userInfoRepository.isExist(uid);
     if (!isExist) {
-      throw new BaseException(
-        ErrorCode.USER_INFO_NOT_FOUND,
-        `UserInfo does not exist. - [${uid}]`,
-      );
+      throw new UserInfoNotFoundException(uid);
     }
 
     await this.userInfoRepository.deleteUserInfoByUid(uid);


### PR DESCRIPTION
## 요약

`BaseException`을 abstract class로 변경하고, 20곳+의 직접 인스턴스화를 14개 도메인별 구체 예외 클래스로 교체하여 자기 문서화, 메시지 일관성, 타입 안전성을 개선한다.

## 변경 사항

- `BaseException`을 abstract class(protected constructor)로 변경하여 직접 인스턴스화 컴파일 타임 차단
- ErrorCode 도메인 그룹과 일치하는 하위 디렉토리에 14개 구체 예외 클래스 생성
  - `auth/`: `AuthUnauthorizedException`, `AuthInvalidPasswordException`, `AuthInvalidOauthTokenException`, `AuthRefreshTokenRequiredException`, `AuthInvalidRefreshTokenException`
  - `user/`: `UserNotFoundException`, `UserAlreadyExistsException`, `UserInfoNotFoundException`, `UserInfoAlreadyExistsException`
  - `blog/`: `PostNotFoundException`, `PostLikeAlreadyExistsException`, `PostLikeNotFoundException`
  - `validation/`: `InvalidPageException`(이동), `InvalidEncryptedParameterException`(신규)
- 각 예외 클래스에 기본 메시지 하드코딩, 컨텍스트 값(uid, postId 등)은 타입화된 생성자 파라미터로 전달
- 기존 `InvalidPageException` → `validation/` 디렉토리로 이동 (re-export로 하위 호환 유지)
- 테스트 assertion을 `BaseException` → 구체 예외 타입으로 강화

## 변경 이유

- `new BaseException(ErrorCode.AUTH_UNAUTHORIZED, 'Unauthorized')`보다 `new AuthUnauthorizedException()`이 의미가 명확 (자기 문서화)
- 동일 ErrorCode에 대해 서로 다른 message 문자열이 전달되는 위험 제거 (메시지 일관성)
- ErrorCode와 message 조합의 정합성을 컴파일 타임에 보장 (타입 안전성)
- `@Catch(BaseException)` 필터는 instanceof 체크이므로 서브클래스 모두 catch하여 하위 호환 유지

## 테스트

- 단위 테스트: 14개 스위트, 72개 테스트 전체 통과
- 빌드: TypeScript 컴파일 성공 (`new BaseException()` 직접 사용 시 컴파일 에러 확인)
- ESLint: 0 에러
- `new BaseException(` grep 검증: src/ 내 0건

## 관련 이슈

Closes #71