### PR TITLE
feat(infra): gitleaks pre-commit 훅 추가 (#78)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+gitleaks protect --staged --redact

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
 npx lint-staged
 if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "[pre-commit] gitleaks 미설치: Windows: choco install gitleaks, Mac: brew install gitleaks, Linux: apt-get install gitleaks"
+  echo "[pre-commit] gitleaks 미설치. 다음 중 하나로 설치 후 다시 시도:"
+  echo "  Windows: choco install gitleaks"
+  echo "  Mac:     brew install gitleaks"
+  echo "  Linux:   apt-get install gitleaks"
   exit 1
 fi
 gitleaks git --staged --pre-commit --redact

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,6 @@
 npx lint-staged
-gitleaks protect --staged --redact
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "[pre-commit] gitleaks 미설치: Windows: choco install gitleaks, Mac: brew install gitleaks, Linux: apt-get install gitleaks"
+  exit 1
+fi
+gitleaks git --staged --pre-commit --redact

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,9 +246,8 @@ TypeORM: 테스트 환경에서 Redis 쿼리 캐시 비활성 (isTestEnv 분기)
 ## Git Hooks (Husky + lint-staged)
 
 - pre-commit: `npx lint-staged` — .ts 파일에 eslint --fix + prettier --write
+- pre-commit: `gitleaks protect --staged --redact` — staged 파일 시크릿 검사 (gitleaks 바이너리 필요: Windows `choco install gitleaks`, Mac `brew install gitleaks`, Linux `apt-get install gitleaks`)
 - pre-push: `npm run build` — 빌드 검증
-
-Phase 0에서 gitleaks pre-commit 라인 추가 예정 (`npx gitleaks protect --staged --redact`).
 
 ## TypeScript / Lint 설정
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ TypeORM: 테스트 환경에서 Redis 쿼리 캐시 비활성 (isTestEnv 분기)
 ## Git Hooks (Husky + lint-staged)
 
 - pre-commit: `npx lint-staged` — .ts 파일에 eslint --fix + prettier --write
-- pre-commit: `gitleaks protect --staged --redact` — staged 파일 시크릿 검사 (gitleaks 바이너리 필요: Windows `choco install gitleaks`, Mac `brew install gitleaks`, Linux `apt-get install gitleaks`)
+- pre-commit: `gitleaks git --staged --pre-commit --redact` — staged 파일 시크릿 검사 (gitleaks 바이너리 필요: Windows `choco install gitleaks`, Mac `brew install gitleaks`, Linux `apt-get install gitleaks`)
 - pre-push: `npm run build` — 빌드 검증
 
 ## TypeScript / Lint 설정

--- a/docs/solution/security.md
+++ b/docs/solution/security.md
@@ -168,7 +168,7 @@
 
 **근거**: OWASP A03/A08 + GitHub Secret Scanning 업계 표준 + 학습 프로젝트에서도 커밋 순간 검출이 방어선 효율적
 
-**구현**: `.husky/pre-commit`에 `npx gitleaks protect --staged --redact` 추가. 로그/에러 메시지에서 시크릿 금지는 NestJS Global Exception Filter가 처리 (기존 구조)
+**구현**: `.husky/pre-commit`에 `gitleaks git --staged --pre-commit --redact` 추가 (gitleaks v8.18+에서 `protect` 명령 deprecated 대응 + npm 패키지 미존재로 binary 설치 전제). 미설치 환경에서는 OS별 설치 안내 후 exit 1로 차단. 로그/에러 메시지에서 시크릿 금지는 NestJS Global Exception Filter가 처리 (기존 구조)
 
 **파급 효과**: Core 재동기화 요청 — application-arch.md Phase 0 로드맵 행에 "gitleaks pre-commit 훅 추가" 보강 필요
 


### PR DESCRIPTION
## What
`.husky/pre-commit`에 `gitleaks git --staged --pre-commit --redact` 추가.
staged 파일 내 시크릿이 감지되면 커밋을 차단한다.

## Why
개발 단계에서 API 키, 토큰, 비밀번호가 실수로 커밋되어 원격 저장소에 노출되는 위험을 pre-commit 단계에서 차단.
`docs/solution/security.md §3 시크릿 관리 [가이드]` 및 Phase 0 로드맵에 명시된 항목.

## How
- `npx gitleaks` 방식은 gitleaks가 npm 패키지가 아니라 Go 바이너리이므로 동작 불가 — 이슈 #78 fallback 경로(binary 설치)로 진행
- `gitleaks protect`는 v8.18+부터 deprecated → `gitleaks git --staged --pre-commit --redact`로 전환
- 미설치 환경에서 `command not found` 대신 OS별 설치 안내 메시지를 한 줄씩 출력하는 가드 추가
- `--redact`: 시크릿 검출 시 출력에서 마스킹 (콘솔 노출 방지)
- `--staged`: staged 파일만 검사

## Test
- gitleaks 설치 후 `gitleaks version` 으로 8.30.1 확인
- 정상 변경 커밋 → pre-commit 통과 확인 (`no leaks found`)
- gitleaks 미설치 환경 시뮬레이션: OS별 설치 안내 메시지 출력 후 exit 1
- 의도적 더미 시크릿(generic-api-key 패턴: `sk_live_4eC39HqLyjWDarjtT1zdp7d…` 32자+) staged 후 `gitleaks git --staged --pre-commit --redact` 실행 → `leaks found: 1`, exit code 1로 차단 확인. `--redact`로 검출 출력 마스킹 동작 확인.
- staged 영역 baseline: 변경 없는 커밋 0건 검출 확인 (`no leaks found`).
- tracked 파일 baseline (`gitleaks dir .` 결과): logs/data/dist/env 등 .gitignore 영역을 제외한 tracked 파일에서 검출되는 더미 시크릿은 Swagger 예제 JWT(`src/user/dto/jwt.dto.ts` × 2) 및 NestJS 보일러플레이트 README 토큰 1건. 본 훅은 staged 변경 라인 단위 검사이므로 해당 라인이 다시 staged 되지 않는 한 영향 없음. 실제 false positive 발생 시 CLAUDE.md에 기재된 `<file>:<rule_id>:<commit>` 형식으로 `.gitleaksignore`에 등록하여 처리.

검증 시 주의: `AKIAIOSFODNN7EXAMPLE`은 gitleaks example allowlist에 포함되어 검출되지 않음. 실제 검증 시 generic 32자+ key 패턴 사용 권장.

Closes #78