### PR TITLE
refactor(config): redisConfig isGlobal 옵션을 최상위로 이동 (#85)

### DIFF
--- a/docs/implementation/issue-plan.md
+++ b/docs/implementation/issue-plan.md
@@ -3,7 +3,7 @@ next-task-policy: small-first
 workers: 1
 assignees: [@dev-msj]
 created-at: 2026-04-25
-last-rebalanced-at: 2026-04-29 — #86 영역 정합 재검사 (Phase 5 deferred → Phase 0 통합)
+last-rebalanced-at: 2026-04-29 — #85 closed + #89 추가 이슈 인덱스 등록 (영역 정합 단일 Phase 미확정 — 사용자 결정 대기)
 ---
 
 # Issue Plan
@@ -24,7 +24,7 @@ last-rebalanced-at: 2026-04-29 — #86 영역 정합 재검사 (Phase 5 deferred
 - #77 [버그] E2E HealthModule CACHE_MANAGER 의존성 해결 (#67 흡수) [closed]
   provides: HealthModule 자기완결성 (CacheModule.registerAsync 내장 import)
   consumes: 없음
-- #85 [리팩토링] redisConfig.ts의 isGlobal 옵션을 CacheModuleAsyncOptions 최상위로 이동
+- #85 [리팩토링] redisConfig.ts의 isGlobal 옵션을 CacheModuleAsyncOptions 최상위로 이동 [closed]
   provides: redisConfig.isGlobal이 CacheModuleAsyncOptions 최상위에서 동작
   consumes: 없음
   coord: #86 — 같은 redisConfig 영역. #86 ioredis Provider 단일화가 #85 의도(글로벌 등록 활성화)를 자연스럽게 흡수할 가능성
@@ -40,10 +40,11 @@ last-rebalanced-at: 2026-04-29 — #86 영역 정합 재검사 (Phase 5 deferred
 ### 추가 이슈 인덱스 (참고)
 - #85 — Phase 0 / 모노 트랙 추가 (#77 PR #83 1차 리뷰에서 생성, contract-impact: additive)
 - #86 — Phase 0 / 모노 트랙 추가 (#77 PR #83 2차 리뷰에서 생성, contract-impact: breaking)
+- #89 — 미통합 / Phase 미정 (#85 PR #87 1차 리뷰에서 생성, contract-impact: none). 영역 정합 검사 결과: Phase 0(TP7 — Node/의존성/migrations) 정합 약함, Phase 1~4 정합 없음, Phase 5(TP8 — NestJS 11 + RFC 9457) 부분 정합. 사용자 결정 대기 — Phase 5 deferred(NestJS 11 업그레이드와 함께 처리) 권고. 마일스톤 미부여.
 
 ### 분류 인덱스 (참고)
 - 기능: #78
-- 버그: #77
+- 버그: #77, #89
 - 리팩토링: #75, #76, #79, #85, #86
 - 인프라: #75, #79
 - 데이터: #79

--- a/src/config/redisConfig.ts
+++ b/src/config/redisConfig.ts
@@ -3,10 +3,10 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import * as redisStore from 'cache-manager-ioredis';
 
 export const redisConfig: CacheModuleAsyncOptions = {
+  isGlobal: true,
   imports: [ConfigModule],
   inject: [ConfigService],
   useFactory: (configService: ConfigService) => ({
-    isGlobal: true,
     store: redisStore,
     host: configService.get('REDIS_HOST'),
     port: Number(configService.get('REDIS_PORT')),


### PR DESCRIPTION
## What
`src/config/redisConfig.ts`의 `isGlobal: true`를 `useFactory` 반환 객체에서 `CacheModuleAsyncOptions` 최상위(= `useFactory`와 동일 레벨)로 이동한다. 기존 위치에서는 cache-manager store 옵션으로 흘러가 NestJS의 글로벌 등록 시멘틱에 닿지 않아, AppModule의 `CacheModule.registerAsync(redisConfig)`가 의도와 달리 글로벌로 등록되지 않던 정합성 문제를 회복한다.

## Why
PR #83 (#77 해결) 1차 코드 리뷰에서 발견된 별건이다. 현재는 `CACHE_MANAGER`를 inject하는 곳이 `redis.health-indicator.ts` 한 곳뿐이고 HealthModule이 자체 `CacheModule.registerAsync(redisConfig)`로 자기완결성을 확보(#77)했기에 동작에는 영향이 없으나, AppModule의 글로벌 등록 의도가 실제로는 미작동하는 상태가 코드와 의도 사이의 정합성을 해친다. 향후 다른 모듈이 명시 import 없이 `CACHE_MANAGER`를 inject하려는 시점에 디버깅 비용이 누적되기 전에 회복한다.

## How
`CacheModuleAsyncOptions`의 `isGlobal`은 모듈 등록 메타이고 `useFactory` 반환 객체의 키들은 cache-manager store(ioredis)로 전달되는 옵션이다. 위치만 이동하면 두 의미가 분리되어 NestJS가 모듈을 글로벌로 등록한다. HealthModule의 자체 `CacheModule.registerAsync(redisConfig)`는 #77 자기완결성 결정에 따라 그대로 유지하므로, 글로벌 등록과 자체 등록이 공존한다.

## Test
- `npm run build` 통과
- `npm run test` 통과 (14 suites, 72 tests)
- `npm run test:e2e` 회귀 검증
  - app/health/user-auth e2e: PASS
  - post.e2e GET/PATCH/DELETE 단건 3건은 본 변경 적용 전 main 브랜치에서도 동일 실패하는 사전 결함으로 확인 (post.e2e는 `overrideModule(CacheModule).useModule(CacheModule.register({ isGlobal: true }))`로 redisConfig 자체를 우회하므로 본 변경의 영향 경로 밖)

## Pre-existing Bug (별도 이관 권고)
회귀 검증 중 발견한 본 PR과 무관한 사전 결함이다. 별도 이슈로 분리한다.

증상: post의 GET/PATCH/DELETE :postId, post-like의 POST/DELETE 5개 엔드포인트가 암호화된 path 파라미터를 항상 errorCode 91001(`INVALID_ENCRYPTED_PARAMETER`)로 거절.

근본 원인: `setupApp`의 전역 `ValidationPipe`(`transform: true`)의 `transformPrimitive`가 `@Param('postId', DecryptPrimaryKeyPipe, ParseIntPipe) postId: number` 패턴에서 사용자 파이프 실행 전 path 파라미터를 `Number(value)`로 변환한다. 암호화된 base64 문자열은 NaN이 되고 `DecryptPrimaryKeyPipe`가 NaN을 받아 복호화 실패. `transformOptions.enableImplicitConversion` 옵션과는 독립이며 `transform: true`만으로 발생.

수정 방향(별도 이슈에서 결정): (1) 5개 컨트롤러 시그니처를 `: string`으로 변경하고 명시 변환, (2) `ValidationPipe` 서브클래싱으로 path 파라미터의 `transformPrimitive` 우회, (3) 다른 아키텍처적 결정. 모두 #85 범위 초과.

Closes #85