### PR TITLE
fix(pipe): path 파라미터 ValidationPipe 우회로 PK 복호화 정상화 (#89)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ src/
 ├── decorator/      # @Public(), @Roles(), @AuthenticatedUserValidation(), @EncryptField()
 ├── filter/         # BaseException / HttpException / Unhandled ExceptionFilter
 ├── interceptor/    # EncryptPrimaryKeyInterceptor
-├── pipe/           # DecryptPrimaryKeyPipe
+├── pipe/           # DecryptPrimaryKeyPipe, PathParamAwareValidationPipe
 ├── exception/      # 도메인별 Custom Exception (auth/, user/, blog/, validation/)
 ├── response/       # BaseResponseDto, SuccessResponse, FailureResponse
 ├── types/          # 공용 타입 선언
@@ -101,13 +101,13 @@ Controller → Service → Repository → Entity
 - Repositories: TypeORM 쿼리
 - DAOs: Entity → DTO 변환
 - DTOs: class-validator 검증
-- Pipes: DecryptPrimaryKeyPipe (암호화된 path param 복호화, 실패 시 InvalidEncryptedParameterException)
+- Pipes: DecryptPrimaryKeyPipe (암호화된 path param 복호화, 실패 시 InvalidEncryptedParameterException), PathParamAwareValidationPipe (전역 ValidationPipe 서브클래스, path 파라미터 transformPrimitive 우회)
 - Interceptors: EncryptPrimaryKeyInterceptor (@EncryptField() 필드 자동 암호화), SetRefreshTokenCookieInterceptor (user 모듈, JwtDto 응답 시 refreshToken 쿠키 자동 설정)
 
 ### App Configuration (setupApp)
 
 - CORS: `enableCors({ origin: true, credentials: true })` — 학습 환경, 프로덕션 배포 트리거 시 allowlist 전환 예정
-- ValidationPipe 전역: `whitelist: true, transform: true, enableImplicitConversion: true`
+- ValidationPipe 전역: `PathParamAwareValidationPipe` (ValidationPipe 서브클래스, `whitelist: true, transform: true, enableImplicitConversion: true`). path 파라미터(`metadata.type === 'param'`)는 우회하여 사용자 파이프(`DecryptPrimaryKeyPipe`, `ParseIntPipe` 등)가 원문을 받도록 보장. body/query/custom은 super 위임
 - cookieParser 미들웨어
 - 전역 Guard: APP_GUARD → AuthGuard (app.module.ts)
 - 전역 Filter: APP_FILTER → BaseExceptionFilter, HttpExceptionFilter, UnhandledExceptionFilter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,7 @@ Phase 1에서 신규 엔드포인트/DTO에 현 패턴(`@ApiOperation`, `@ApiPro
 - 쿼리 최적화: find/findOne 호출 시 select로 컬럼 명시, 민감 컬럼(password, salt) 제외
 - 환경변수: `process.env` 직접 접근 금지. `ConfigService` 또는 `@Inject(config.KEY)` 사용
 - Global Module: Phase 2 observability 모듈은 NestJS Global Module로 등록하여 feature 모듈에서 import 없이 inject 가능하게 구성
+- Path 파라미터 변환: 전역 `PathParamAwareValidationPipe`가 path param의 ValidationPipe `transformPrimitive`를 우회하므로, 핸들러가 `: number`/`: boolean` 등 원시 타입을 받으려면 `@Param('name', ParseIntPipe)` 형태로 적합한 `Parse*Pipe` 또는 `DecryptPrimaryKeyPipe`를 명시 부착해야 한다. 시그니처만 `: number`로 두면 string 원문이 흘러 typeof 단언이 깨진다 (정적 분석 미감지)
 
 ## [확정]/[가이드] 구분
 

--- a/src/config/app-setup.ts
+++ b/src/config/app-setup.ts
@@ -1,5 +1,6 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
+import { PathParamAwareValidationPipe } from '../pipe/path-param-aware-validation.pipe';
 
 /**
  * NestJS 앱의 공통 설정을 적용
@@ -13,7 +14,7 @@ export function setupApp(app: INestApplication): void {
   });
 
   app.useGlobalPipes(
-    new ValidationPipe({
+    new PathParamAwareValidationPipe({
       whitelist: true,
       transform: true,
       transformOptions: { enableImplicitConversion: true },

--- a/src/pipe/path-param-aware-validation.pipe.spec.ts
+++ b/src/pipe/path-param-aware-validation.pipe.spec.ts
@@ -101,5 +101,24 @@ describe('PathParamAwareValidationPipe', () => {
       expect(result).toBeInstanceOf(SampleNumericDto);
       expect(result.page).toBe(3);
     });
+
+    it('custom 타입은 super.transform에 위임된다 (validateCustomDecorators 옵션 진화 가드)', async () => {
+      // Given: 'custom'은 ValidationPipe의 validateCustomDecorators 옵션이 동작 분기.
+      // 본 파이프는 'custom'을 우회 대상에 포함하지 않으므로 super 위임이 보장되어야 한다.
+      const superTransformSpy = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(pipe)),
+        'transform',
+      );
+      const metadata: ArgumentMetadata = {
+        type: 'custom',
+        metatype: String,
+        data: 'header',
+      };
+
+      await pipe.transform('value', metadata);
+
+      expect(superTransformSpy).toHaveBeenCalledWith('value', metadata);
+      superTransformSpy.mockRestore();
+    });
   });
 });

--- a/src/pipe/path-param-aware-validation.pipe.spec.ts
+++ b/src/pipe/path-param-aware-validation.pipe.spec.ts
@@ -1,0 +1,105 @@
+import { ArgumentMetadata, BadRequestException } from '@nestjs/common';
+import { IsInt, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PathParamAwareValidationPipe } from './path-param-aware-validation.pipe';
+
+class SampleBodyDto {
+  @IsString()
+  readonly title: string;
+}
+
+class SampleQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  readonly page: number;
+}
+
+describe('PathParamAwareValidationPipe', () => {
+  const pipe = new PathParamAwareValidationPipe({
+    whitelist: true,
+    transform: true,
+    transformOptions: { enableImplicitConversion: true },
+  });
+
+  describe('path 파라미터 (metadata.type === "param")', () => {
+    it('암호화된 base64 문자열을 Number 변환 없이 그대로 반환한다', async () => {
+      // Given: ValidationPipe 기본 동작이라면 Number(value) → NaN이 발생하는 시나리오
+      const encrypted = 'U2FsdGVkX1+abc/def==';
+      const metadata: ArgumentMetadata = {
+        type: 'param',
+        metatype: Number,
+        data: 'postId',
+      };
+
+      // When
+      const result = await pipe.transform(encrypted, metadata);
+
+      // Then: 원본 문자열 그대로
+      expect(result).toBe(encrypted);
+      expect(Number.isNaN(result)).toBe(false);
+    });
+
+    it('metatype이 String인 path param도 그대로 반환한다', async () => {
+      const value = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const metadata: ArgumentMetadata = {
+        type: 'param',
+        metatype: String,
+        data: 'postUid',
+      };
+
+      const result = await pipe.transform(value, metadata);
+
+      expect(result).toBe(value);
+    });
+
+    it('metatype이 없는 path param도 그대로 반환한다', async () => {
+      const value = 'arbitrary-value';
+      const metadata: ArgumentMetadata = { type: 'param', data: 'id' };
+
+      const result = await pipe.transform(value, metadata);
+
+      expect(result).toBe(value);
+    });
+  });
+
+  describe('body / query는 super.transform에 위임된다', () => {
+    it('body DTO는 class-validator 검증과 transform이 수행된다', async () => {
+      const metadata: ArgumentMetadata = {
+        type: 'body',
+        metatype: SampleBodyDto,
+        data: '',
+      };
+
+      const result = await pipe.transform({ title: 'hello' }, metadata);
+
+      expect(result).toBeInstanceOf(SampleBodyDto);
+      expect(result.title).toBe('hello');
+    });
+
+    it('body DTO 검증 실패 시 BadRequestException을 던진다', async () => {
+      const metadata: ArgumentMetadata = {
+        type: 'body',
+        metatype: SampleQueryDto,
+        data: '',
+      };
+
+      await expect(pipe.transform({ page: 0 }, metadata)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('query DTO는 @Type 변환이 적용된다', async () => {
+      const metadata: ArgumentMetadata = {
+        type: 'query',
+        metatype: SampleQueryDto,
+        data: '',
+      };
+
+      const result = await pipe.transform({ page: '3' }, metadata);
+
+      expect(result).toBeInstanceOf(SampleQueryDto);
+      expect(result.page).toBe(3);
+    });
+  });
+});

--- a/src/pipe/path-param-aware-validation.pipe.spec.ts
+++ b/src/pipe/path-param-aware-validation.pipe.spec.ts
@@ -3,12 +3,12 @@ import { IsInt, IsString, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 import { PathParamAwareValidationPipe } from './path-param-aware-validation.pipe';
 
-class SampleBodyDto {
+class SampleStringDto {
   @IsString()
   readonly title: string;
 }
 
-class SampleQueryDto {
+class SampleNumericDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
@@ -67,20 +67,20 @@ describe('PathParamAwareValidationPipe', () => {
     it('body DTO는 class-validator 검증과 transform이 수행된다', async () => {
       const metadata: ArgumentMetadata = {
         type: 'body',
-        metatype: SampleBodyDto,
+        metatype: SampleStringDto,
         data: '',
       };
 
       const result = await pipe.transform({ title: 'hello' }, metadata);
 
-      expect(result).toBeInstanceOf(SampleBodyDto);
+      expect(result).toBeInstanceOf(SampleStringDto);
       expect(result.title).toBe('hello');
     });
 
     it('body DTO 검증 실패 시 BadRequestException을 던진다', async () => {
       const metadata: ArgumentMetadata = {
         type: 'body',
-        metatype: SampleQueryDto,
+        metatype: SampleNumericDto,
         data: '',
       };
 
@@ -92,13 +92,13 @@ describe('PathParamAwareValidationPipe', () => {
     it('query DTO는 @Type 변환이 적용된다', async () => {
       const metadata: ArgumentMetadata = {
         type: 'query',
-        metatype: SampleQueryDto,
+        metatype: SampleNumericDto,
         data: '',
       };
 
       const result = await pipe.transform({ page: '3' }, metadata);
 
-      expect(result).toBeInstanceOf(SampleQueryDto);
+      expect(result).toBeInstanceOf(SampleNumericDto);
       expect(result.page).toBe(3);
     });
   });

--- a/src/pipe/path-param-aware-validation.pipe.ts
+++ b/src/pipe/path-param-aware-validation.pipe.ts
@@ -11,6 +11,12 @@ import { ArgumentMetadata, Injectable, ValidationPipe } from '@nestjs/common';
  * 본 클래스는 `metadata.type === 'param'`일 때 ValidationPipe 처리를 우회하여
  * 사용자 파이프 체인이 원문을 그대로 받도록 보장한다. body/query/custom은
  * 기존 동작을 유지한다.
+ *
+ * TODO(Phase 2 observability / Phase 5 NestJS 11): 부모 ValidationPipe.transform
+ * 내부에 cross-cutting 로직(OTel trace span, 추가 보안 검증 등)이 도입되면
+ * param 분기에서 누락된다. Phase 2 OpenTelemetry 도입 시 path param trace 누락
+ * 점검 필요. Phase 5 NestJS 11 업그레이드 시 부모 transform 내부 동작 변경에
+ * 대한 회귀 검증을 본 클래스 책임으로 포함.
  */
 @Injectable()
 export class PathParamAwareValidationPipe extends ValidationPipe {

--- a/src/pipe/path-param-aware-validation.pipe.ts
+++ b/src/pipe/path-param-aware-validation.pipe.ts
@@ -1,0 +1,26 @@
+import { ArgumentMetadata, Injectable, ValidationPipe } from '@nestjs/common';
+
+/**
+ * 전역 ValidationPipe 확장. NestJS 파이프 실행 순서상 global pipe가 param-level
+ * 사용자 파이프(예: DecryptPrimaryKeyPipe, ParseIntPipe)보다 먼저 실행되며,
+ * `transform: true`의 transformPrimitive가 컨트롤러 시그니처의 `: number`로부터
+ * metatype=Number를 추론해 path 파라미터에 `Number(value)`를 적용한다.
+ * 이 동작은 암호화된 path 파라미터(예: AES base64)를 NaN으로 변환해
+ * 후속 사용자 파이프의 복호화를 차단한다.
+ *
+ * 본 클래스는 `metadata.type === 'param'`일 때 ValidationPipe 처리를 우회하여
+ * 사용자 파이프 체인이 원문을 그대로 받도록 보장한다. body/query/custom은
+ * 기존 동작을 유지한다.
+ */
+@Injectable()
+export class PathParamAwareValidationPipe extends ValidationPipe {
+  override async transform(
+    value: any,
+    metadata: ArgumentMetadata,
+  ): Promise<any> {
+    if (metadata.type === 'param') {
+      return value;
+    }
+    return super.transform(value, metadata);
+  }
+}


### PR DESCRIPTION
## What

전역 `ValidationPipe(transform: true)`가 NestJS 파이프 실행 순서상 param-level 사용자 파이프(`DecryptPrimaryKeyPipe`, `ParseIntPipe`)보다 먼저 실행되어, 컨트롤러 시그니처 `: number`로부터 추론된 `metatype=Number`로 암호화된 base64 path 파라미터에 `Number()`를 적용해 NaN으로 변환하던 결함 수정.

원인: `transformPrimitive`는 `transform: true`만으로 활성되며 `enableImplicitConversion`과 독립적이라 옵션 변경으로 회피 불가.

해결: `ValidationPipe`를 상속한 `PathParamAwareValidationPipe`가 `metadata.type === 'param'`일 때 값을 그대로 반환하고 body/query/custom은 `super.transform`에 위임. 5개 엔드포인트(`GET/PATCH/DELETE /posts/:postId`, `POST/DELETE /posts/:postId/likes`)의 `InvalidEncryptedParameterException(91001)` 해소.

## Why

5개 production 엔드포인트가 깨진 상태로 Phase 1 신규 기능 회귀 베이스라인을 신뢰할 수 없어 Phase 1 진입 전 처리 필요. PR #87 회귀 검증 과정에서 발견.

## How

채택 방안과 대안 평가:

(1) 5개 핸들러 시그니처 `: number` → `: string` + 명시 변환 — 5개 변경점 + ParseIntPipe 사용 불가. 기각.
(2) ValidationPipe 서브클래스 — 단일 인프라 변경점, 5개 핸들러 시그니처 무손, ParseIntPipe NaN 처리 정상 동작. 채택.
(3) `@EncryptedIdParam` 커스텀 데코레이터 — 새 추상화 + 5개 변경점. 기각.

선정 사유: NestJS `transform(value, metadata)` public API 시그니처는 NestJS 10/11 동일. 본 프로젝트의 모든 path param은 `@Param(...pipes)`로 사용자 파이프가 명시 부착되어 ValidationPipe-only 검증에 의존하는 경로가 없어 회귀 위험이 낮다.

핵심 코드:

```typescript
@Injectable()
export class PathParamAwareValidationPipe extends ValidationPipe {
  override async transform(value: any, metadata: ArgumentMetadata): Promise<any> {
    if (metadata.type === 'param') return value;
    return super.transform(value, metadata);
  }
}
```

## Test

- 단위 테스트 6건 신규 (`src/pipe/path-param-aware-validation.pipe.spec.ts`):
  - param: 암호화된 base64 / String metatype / metatype 없음 — 모두 원문 반환 + `Number.isNaN(result) === false`로 결함 역증명
  - body/query: super 위임 동작 확인 (DTO 검증·transform·@Type 변환·검증 실패 시 BadRequestException)
- 단위 테스트 전체 78/78 통과
- E2E 4 suites/15 tests 통과 — `post.e2e-spec.ts`의 단건 조회/수정/삭제 3건이 수정 전 실패 → 수정 후 통과
- B5 검증: work-analyzer 통과 (Minor 1건 fixture 명명 반영 완료), test-analyzer 통과

post-like 컨트롤러 E2E 부재는 본 PR 범위 외 (별도 커버리지 부채). `metadata.type === 'param'` 단일 조건 동작이라 동일 패턴이 검증된 3개 엔드포인트로 메커니즘 충분히 검증됨.

Closes #89
Related to #85